### PR TITLE
#61 Users API resources location fix

### DIFF
--- a/src/routes/routes.module.ts
+++ b/src/routes/routes.module.ts
@@ -19,7 +19,7 @@ const routes: Routes = [
         module: ApiModule,
         children: [
             {
-                path: '/user',
+                path: '/users',
                 module: UserModule,
             },
             {
@@ -31,7 +31,7 @@ const routes: Routes = [
                 module: AdminModule,
                 children: [
                     {
-                        path: '/user',
+                        path: '/users',
                         module: AdminUserModule,
                     },
                     {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -161,16 +161,16 @@ describe('AppController (e2e)', () => {
     });
 
     describe('/ADMIN', () => {
-        describe('/USER', () => {
+        describe('/USERS', () => {
             it(
-                'should not allow to access admin route without proper rights GET /api/admin/user',
+                'should not allow to access admin route without proper rights GET /api/admin/users',
                 async () => {
                     const loginRes = await request(app.getHttpServer())
                         .post('/auth/login')
                         .send({ login: 'user1', password: '12345678' });
 
                     return request(app.getHttpServer())
-                        .get('/api/admin/user')
+                        .get('/api/admin/users')
                         .set('Cookie', loginRes.get('Set-Cookie'))
                         .expect(403)
                         .expect({
@@ -182,14 +182,14 @@ describe('AppController (e2e)', () => {
             );
 
             it(
-                'should allow to access admin route for admin GET /api/admin/user',
+                'should allow to access admin route for admin GET /api/admin/users',
                 async () => {
                     const loginRes = await request(app.getHttpServer())
                         .post('/auth/login')
                         .send({ login: 'admin', password: '12345678' });
 
                     return request(app.getHttpServer())
-                        .get('/api/admin/user')
+                        .get('/api/admin/users')
                         .set('Cookie', loginRes.get('Set-Cookie'))
                         .expect(200);
                 },


### PR DESCRIPTION
Resolves #61 

`/api/user` -> `/api/users`
`/api/admin/user` -> `/api/admin/users`

Тесты так же исправлены.