### PR TITLE
[#85] Refactor tests - use strict types

### DIFF
--- a/src/routes/api/admin/user/dto/GetAdminUsersResponse.dto.ts
+++ b/src/routes/api/admin/user/dto/GetAdminUsersResponse.dto.ts
@@ -1,12 +1,27 @@
-import { AdminUser, GetAdminUsersResponse as Response } from '@lib-shikicinema';
+import { AdminUserInfo } from '@app-routes/api/admin/user/dto/AdminUserInfo.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import { GetAdminUsersResponse as Response } from '@lib-shikicinema';
 
 export class GetAdminUsersResponse implements Response {
-    data: AdminUser[];
+    @Expose()
+    @Type(() => AdminUserInfo)
+    @ApiProperty()
+    data: AdminUserInfo[];
+
+    @Expose()
+    @ApiProperty()
     limit: number;
+
+    @Expose()
+    @ApiProperty()
     offset: number;
+
+    @Expose()
+    @ApiProperty()
     total: number;
 
-    constructor(data: AdminUser[], limit: number, offset: number, total: number) {
+    constructor(data?: AdminUserInfo[], limit?: number, offset?: number, total?: number) {
         this.data = data;
         this.limit = limit;
         this.offset = offset;

--- a/src/routes/api/author/dto/Author.dto.ts
+++ b/src/routes/api/author/dto/Author.dto.ts
@@ -13,7 +13,9 @@ export class Author implements Interface {
     @ApiProperty()
     name: string;
 
-    constructor(author: AuthorEntity) {
+    constructor(author?: AuthorEntity) {
+        if (!author) return;
+
         const { id, name } = author;
 
         this.id = id;

--- a/src/routes/api/author/dto/GetAuthorResponse.dto.ts
+++ b/src/routes/api/author/dto/GetAuthorResponse.dto.ts
@@ -1,13 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Author } from '@app-routes/api/author/dto/Author.dto';
+import { Expose, Type } from 'class-transformer';
 import { GetAuthorResponse as Response } from '@lib-shikicinema';
 
 export class GetAuthorResponse implements Response {
+    @Expose()
+    @Type(() => Author)
+    @ApiProperty()
     data: Author[];
+
+    @Expose()
+    @ApiProperty()
     limit: number;
+
+    @Expose()
+    @ApiProperty()
     offset: number;
+
+    @Expose()
+    @ApiProperty()
     total: number;
 
-    constructor(data: Author[], limit: number, offset: number, total: number) {
+    constructor(data?: Author[], limit?: number, offset?: number, total?: number) {
         this.limit = limit;
         this.offset = offset;
         this.data = data;

--- a/src/routes/api/video/dto/GetEpisodesResponse.dto.ts
+++ b/src/routes/api/video/dto/GetEpisodesResponse.dto.ts
@@ -1,11 +1,12 @@
 import { AnimeEpisodeInfo } from '@app-routes/api/video/dto';
 import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import { GetEpisodesResponse as Response } from '@lib-shikicinema';
 
 export class GetEpisodesResponse implements Response {
     @Expose()
     @ApiProperty()
+    @Type(() => AnimeEpisodeInfo)
     data: AnimeEpisodeInfo[];
 
     @Expose()
@@ -20,7 +21,7 @@ export class GetEpisodesResponse implements Response {
     @ApiProperty()
     total: number;
 
-    constructor(data: AnimeEpisodeInfo[], limit: number, offset: number, total: number) {
+    constructor(data?: AnimeEpisodeInfo[], limit?: number, offset?: number, total?: number) {
         this.data = data;
         this.limit = limit;
         this.offset = offset;

--- a/src/routes/api/video/dto/GetVideosResponse.dto.ts
+++ b/src/routes/api/video/dto/GetVideosResponse.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import { GetVideosResponse as Response } from '@lib-shikicinema';
 import { VideoResponse } from '@app-routes/api/video/dto/VideoResponse.dto';
 
 export class GetVideosResponse implements Response {
     @Expose()
     @ApiProperty()
+    @Type(() => VideoResponse)
     data: VideoResponse[];
 
     @Expose()
@@ -20,7 +21,7 @@ export class GetVideosResponse implements Response {
     @ApiProperty()
     total: number;
 
-    constructor(data: VideoResponse[], limit: number, offset: number, total: number) {
+    constructor(data?: VideoResponse[], limit?: number, offset?: number, total?: number) {
         this.data = data;
         this.limit = limit;
         this.offset = offset;

--- a/src/routes/api/video/dto/VideoResponse.dto.ts
+++ b/src/routes/api/video/dto/VideoResponse.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Author } from '@app-routes/api/author/dto/Author.dto';
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import { UploaderInfo } from '@app-routes/auth/dto';
 import { Video, VideoKindEnum, VideoQualityEnum } from '@lib-shikicinema';
 import { VideoEntity } from '@app-entities';
@@ -16,6 +16,7 @@ export class VideoResponse implements Video {
 
     @Expose()
     @ApiProperty()
+    @Type(() => Author)
     author: Author;
 
     @Expose()
@@ -36,6 +37,7 @@ export class VideoResponse implements Video {
 
     @Expose()
     @ApiProperty({ type: () => UploaderInfo })
+    @Type(() => UploaderInfo)
     uploader: UploaderInfo;
 
     @Expose()
@@ -47,12 +49,16 @@ export class VideoResponse implements Video {
     watchesCount: number;
 
     @ApiProperty()
+    @Type(() => Date)
     createdAt: Date;
 
     @ApiProperty()
+    @Type(() => Date)
     updatedAt: Date;
 
-    constructor(entity: VideoEntity) {
+    constructor(entity?: VideoEntity) {
+        if (!entity) return;
+
         const {
             id,
             animeId,

--- a/src/routes/auth/dto/OwnerUserInfo.dto.ts
+++ b/src/routes/auth/dto/OwnerUserInfo.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 import { Role } from '@lib-shikicinema';
 import { TransformRoles } from '@app-utils/class-transform.utils';
 import { UserEntity } from '@app-entities';
@@ -36,13 +36,17 @@ export class OwnerUserInfo {
 
     @Expose()
     @ApiProperty()
+    @Type(() => Date)
     createdAt: Date;
 
     @Expose()
     @ApiProperty()
+    @Type(() => Date)
     updatedAt: Date;
 
-    constructor(entity: UserEntity) {
+    constructor(entity?: UserEntity) {
+        if (!entity) return;
+
         const {
             id,
             login,

--- a/src/routes/auth/dto/UploaderInfo.dto.ts
+++ b/src/routes/auth/dto/UploaderInfo.dto.ts
@@ -17,7 +17,9 @@ export class UploaderInfo implements Uploader {
     @ApiProperty()
     shikimoriId: string;
 
-    constructor(entity: UploaderEntity) {
+    constructor(entity?: UploaderEntity) {
+        if (!entity) return;
+
         const { id, banned, shikimoriId } = entity;
         this.id = id;
         this.banned = banned;

--- a/test/spec/author.e2e.spec.ts
+++ b/test/spec/author.e2e.spec.ts
@@ -1,5 +1,5 @@
+import { Author, GetAuthorResponse } from '@app-routes/api/author/dto';
 import { AuthorEntity } from '@app-entities';
-import { GetAuthorResponse } from '@app-routes/api/author/dto';
 import { GetAuthorsRequest } from '@lib-shikicinema';
 import { Raw } from 'typeorm';
 import { TestEnvironment } from '@e2e/test.environment';
@@ -23,10 +23,7 @@ describe('Authors API (e2e)', () => {
             const res = await env.anonClient.getAuthors(req);
 
             expect(res.data.length).toBe(1);
-            expect(res.data[0]).toStrictEqual({
-                id: author.id,
-                name: author.name,
-            });
+            expect(res.data[0]).toStrictEqual(new Author(author));
             expect(res.limit).toBe(20);
             expect(res.offset).toBe(0);
             expect(res.total).toBe(1);
@@ -46,7 +43,7 @@ describe('Authors API (e2e)', () => {
 
             const res = await env.anonClient.getAuthors();
             expect(res.data.length).toBe(authors.length);
-            expect(res).toEqual(new GetAuthorResponse(authors, 20, 0, total));
+            expect(res).toStrictEqual(new GetAuthorResponse(authors.map((_) => new Author(_)), 20, 0, total));
         },
     );
 


### PR DESCRIPTION
Closes: #85

Основное изменение: тестовый клиент теперь возвращает не JavaScript Object, а именно класс dto.
Теперь можно делать toStrictEqual сравнивая ответ от API и dto которое было создано в тесте.