### PR TITLE
#105 Вынести роли у пользователя в отдельную таблицу

### DIFF
--- a/projects/backend/liquibase.js
+++ b/projects/backend/liquibase.js
@@ -16,9 +16,9 @@ dotenv.config();
         await liquibase({
             username,
             password,
-            changeLogFile: path.resolve('migrations', 'index.xml'),
+            changeLogFile: path.resolve(__dirname, 'migrations', 'index.xml'),
             url: `jdbc:postgresql://${host}:${port}/${database}`,
-            classpath: path.resolve('node_modules', 'liquibase', 'lib', 'Drivers', 'postgresql-42.2.8.jar'),
+            classpath: path.resolve('../../node_modules', 'liquibase', 'lib', 'Drivers', 'postgresql-42.2.8.jar'),
         }).run('update');
         console.log('Migration was successful');
     } catch (e) {

--- a/projects/backend/migrations/2022-10-22-02-create-authors.xml
+++ b/projects/backend/migrations/2022-10-22-02-create-authors.xml
@@ -39,9 +39,9 @@
 
         <dropColumn tableName="videos" columnName="author"/>
 
-        <createIndex indexName="authors_upper_name_uniq" tableName="authors" unique="true"> 
-            <column name="UPPER(name)" computed="true"/> 
-        </createIndex> 
+        <createIndex indexName="authors_upper_name_uniq" tableName="authors" unique="true">
+            <column name="UPPER(name)" computed="true"/>
+        </createIndex>
 
     </changeSet>
 </databaseChangeLog>

--- a/projects/backend/migrations/2023-03-31-01-create-user_roles.xml
+++ b/projects/backend/migrations/2023-03-31-01-create-user_roles.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <changeSet id="2023-03-31-01-create-user_roles" author="Smarthard">
+
+        <createTable tableName="user_roles">
+
+            <column name="user_id" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="smallint">
+                <constraints nullable="false"/>
+            </column>
+
+        </createTable>
+
+        <sql>
+            INSERT INTO user_roles (user_id, role) SELECT id AS user_id, unnest(roles) AS roles FROM users;
+        </sql>
+
+        <addForeignKeyConstraint baseTableName="user_roles"
+                                 baseColumnNames="user_id"
+                                 constraintName="fk_user_id"
+                                 onUpdate="CASCADE"
+                                 onDelete="CASCADE"
+                                 referencedTableName="users"
+                                 referencedColumnNames="id"/>
+
+        <addPrimaryKey tableName="user_roles"
+                       columnNames="user_id, role" />
+
+        <dropColumn tableName="users" columnName="roles"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/projects/backend/migrations/index.xml
+++ b/projects/backend/migrations/index.xml
@@ -17,6 +17,7 @@
     <include file="2022-07-30-01-add-column-sessions-destroyed_at.xml" relativeToChangelogFile="true"/>
     <include file="2022-08-04-01-change-column-sessions-destroyed_at.xml" relativeToChangelogFile="true"/>
     <include file="2022-10-22-01-remove-video-cascading-deletion.xml" relativeToChangelogFile="true"/>
-    <include file="2022-10-22-02-create-authors.xml" relativeToChangelogFile="true"/> 
+    <include file="2022-10-22-02-create-authors.xml" relativeToChangelogFile="true"/>
+    <include file="2023-03-31-01-create-user_roles.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/projects/backend/seeds/1607357974819-user-seed.ts
+++ b/projects/backend/seeds/1607357974819-user-seed.ts
@@ -1,15 +1,14 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
-import { Role } from '@shikicinema/types';
 import { UserEntity } from '~backend/entities';
 
-export const seeds = [
-    new UserEntity('admin', '12345678', 'admin@email.com', [Role.admin, Role.user]),
-    new UserEntity('user1', '12345678', 'user1@email.com', [Role.user]),
-    new UserEntity('user2', '12345678', 'user2@email.com', [Role.user]),
-    new UserEntity('banned', '12345678', 'banned@email.com', [Role.user, Role.banned]),
+const seeds = [
+    new UserEntity('admin', '12345678', 'admin@email.com'),
+    new UserEntity('user1', '12345678', 'user1@email.com'),
+    new UserEntity('user2', '12345678', 'user2@email.com'),
+    new UserEntity('banned', '12345678', 'banned@email.com'),
 ];
 
-export class UserSeed21607357974819 implements MigrationInterface {
+export class UserSeed1607357974819 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         const usersRepo = await queryRunner.manager.getRepository(UserEntity);
         await usersRepo.save(seeds);

--- a/projects/backend/seeds/1607357974820-user-roles-seed.ts
+++ b/projects/backend/seeds/1607357974820-user-roles-seed.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { Role } from '@shikicinema/types';
+import { UserEntity, UserRolesEntity } from '~backend/entities';
+
+const seeds = [];
+
+export class UserRolesSeed1607357974820 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const userRepo = await queryRunner.manager.getRepository(UserEntity);
+        const userRolesRepo = await queryRunner.manager.getRepository(UserRolesEntity);
+
+        const admin = await userRepo.findOneByOrFail({ login: 'admin' });
+        const user1 = await userRepo.findOneByOrFail({ login: 'user1' });
+        const user2 = await userRepo.findOneByOrFail({ login: 'user2' });
+        const banned = await userRepo.findOneByOrFail({ login: 'banned' });
+
+        seeds.push(
+            // admin roles
+            new UserRolesEntity(admin, Role.user),
+            new UserRolesEntity(admin, Role.admin),
+
+            // user1 roles
+            new UserRolesEntity(user1, Role.user),
+
+            // user2 roles
+            new UserRolesEntity(user2, Role.user),
+
+            // banned roles
+            new UserRolesEntity(banned, Role.user),
+            new UserRolesEntity(banned, Role.banned),
+        );
+
+        await userRolesRepo.save(seeds);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const userRolesRepo = await queryRunner.manager.getRepository(UserRolesEntity);
+        await userRolesRepo.clear();
+    }
+}

--- a/projects/backend/seeds/1607704017485-session-seed.ts
+++ b/projects/backend/seeds/1607704017485-session-seed.ts
@@ -15,7 +15,7 @@ const sessionData = {
     },
 };
 
-export const seeds = [
+const seeds = [
     new SessionEntity('1', expireDateMsTomorrow, JSON.stringify(sessionData)),
 ];
 

--- a/projects/backend/seeds/1621024400000-authors-seed.ts
+++ b/projects/backend/seeds/1621024400000-authors-seed.ts
@@ -1,7 +1,7 @@
 import { AuthorEntity } from '~backend/entities';
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export const seeds = [
+const seeds = [
     new AuthorEntity('AniDUB'),
     new AuthorEntity('AniLibria.TV'),
     new AuthorEntity('AnimeVost'),

--- a/projects/backend/seeds/index.ts
+++ b/projects/backend/seeds/index.ts
@@ -1,0 +1,7 @@
+export * from '~backend-root/seeds/1607357974819-user-seed';
+export * from '~backend-root/seeds/1607357974820-user-roles-seed';
+export * from '~backend-root/seeds/1607704017485-session-seed';
+export * from '~backend-root/seeds/1621024303293-uploader-seed';
+export * from '~backend-root/seeds/1621024400000-authors-seed';
+export * from '~backend-root/seeds/1621024590642-video-seed';
+export * from '~backend-root/seeds/1650995411336-upload-token-seed';

--- a/projects/backend/src/config/database.config.ts
+++ b/projects/backend/src/config/database.config.ts
@@ -1,14 +1,17 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { SqliteConnectionOptions } from 'typeorm/driver/sqlite/SqliteConnectionOptions';
-import { entities } from '~backend/entities';
 import { registerAs } from '@nestjs/config';
 
-import { AuthorsSeed1621024400000 } from '~backend-root/seeds/1621024400000-authors-seed';
-import { SessionSeed1607704017485 } from '~backend-root/seeds/1607704017485-session-seed';
-import { UploadTokenSeed1650995411336 } from '~backend-root/seeds/1650995411336-upload-token-seed';
-import { UploaderSeed1621024303293 } from '~backend-root/seeds/1621024303293-uploader-seed';
-import { UserSeed21607357974819 } from '~backend-root/seeds/1607357974819-user-seed';
-import { VideoSeed1621024590642 } from '~backend-root/seeds/1621024590642-video-seed';
+import {
+    AuthorsSeed1621024400000,
+    SessionSeed1607704017485,
+    UploadTokenSeed1650995411336,
+    UploaderSeed1621024303293,
+    UserRolesSeed1607357974820,
+    UserSeed1607357974819,
+    VideoSeed1621024590642,
+} from '~backend-root/seeds';
+import { entities } from '~backend/entities';
 
 export default registerAs('database', () => {
     const postgresConfig: PostgresConnectionOptions = {
@@ -21,6 +24,8 @@ export default registerAs('database', () => {
         logging: !!process.env.SHIKICINEMA_DB_LOG,
         synchronize: !!process.env.SHIKICINEMA_DB_SYNC,
         entities,
+        // see: https://orkhan.gitbook.io/typeorm/docs/data-source-options#common-data-source-options (entitySkipConstructor)
+        entitySkipConstructor: true,
     };
 
     const inMemoryConfig: SqliteConnectionOptions = {
@@ -30,13 +35,15 @@ export default registerAs('database', () => {
         logging: false,
         synchronize: true,
         migrations: [
-            UserSeed21607357974819,
+            UserSeed1607357974819,
             SessionSeed1607704017485,
             UploaderSeed1621024303293,
             AuthorsSeed1621024400000,
             VideoSeed1621024590642,
             UploadTokenSeed1650995411336,
+            UserRolesSeed1607357974820,
         ],
+        entitySkipConstructor: true,
     };
 
     return process.env.NODE_ENV === 'testing' ? inMemoryConfig : postgresConfig;

--- a/projects/backend/src/entities/index.ts
+++ b/projects/backend/src/entities/index.ts
@@ -3,6 +3,7 @@ import { SessionEntity } from '~backend/entities/session';
 import { UploadTokenEntity } from '~backend/entities/upload-token';
 import { UploaderEntity } from '~backend/entities/uploader';
 import { UserEntity } from '~backend/entities/user';
+import { UserRolesEntity } from '~backend/entities/user-roles';
 import { VideoEntity } from '~backend/entities/video';
 
 export const entities = [
@@ -12,6 +13,7 @@ export const entities = [
     UploadTokenEntity,
     SessionEntity,
     VideoEntity,
+    UserRolesEntity,
 ];
 
 export { AuthorEntity } from '~backend/entities/author';
@@ -20,3 +22,4 @@ export { UploadTokenEntity } from '~backend/entities/upload-token';
 export { UploaderEntity } from '~backend/entities/uploader';
 export { UserEntity } from '~backend/entities/user';
 export { VideoEntity } from '~backend/entities/video';
+export { UserRolesEntity } from '~backend/entities/user-roles';

--- a/projects/backend/src/entities/uploader.ts
+++ b/projects/backend/src/entities/uploader.ts
@@ -21,7 +21,7 @@ export class UploaderEntity {
     @Column()
     banned: boolean;
 
-    @OneToOne(() => UserEntity, (user) => user.id)
+    @OneToOne(() => UserEntity, (user) => user)
     @JoinColumn({ name: 'user_id' })
     user: UserEntity;
 

--- a/projects/backend/src/entities/user-roles.ts
+++ b/projects/backend/src/entities/user-roles.ts
@@ -1,0 +1,27 @@
+import {
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from 'typeorm';
+import { Role } from '@shikicinema/types';
+import { UserEntity } from '~backend/entities/user';
+
+@Entity('user_roles')
+export class UserRolesEntity {
+    @PrimaryColumn({ name: 'user_id' })
+    userId: number;
+
+    @PrimaryColumn()
+    role: Role;
+
+    @ManyToOne(() => UserEntity, ({ roles }) => roles)
+    @JoinColumn({ name: 'user_id', foreignKeyConstraintName: 'user_id' })
+    user!: UserEntity;
+
+    constructor(user: UserEntity, role: Role) {
+        this.userId = user.id;
+        this.user = user;
+        this.role = role;
+    }
+}

--- a/projects/backend/src/entities/user.spec.ts
+++ b/projects/backend/src/entities/user.spec.ts
@@ -1,5 +1,4 @@
 import * as bcrypt from 'bcrypt';
-import { Role } from '@shikicinema/types';
 
 import { UserEntity } from '~backend/entities';
 
@@ -12,7 +11,6 @@ describe('UserEntity', () => {
         expect(entity.name).toBe(login);
         expect(entity.password).toBe(password);
         expect(entity.email).toBe(email);
-        expect(entity.roles).toStrictEqual([Role.user]);
         expect(entity.uploader).toBe(null);
     });
 

--- a/projects/backend/src/entities/user.ts
+++ b/projects/backend/src/entities/user.ts
@@ -3,15 +3,16 @@ import {
     BeforeInsert,
     Column,
     CreateDateColumn,
-    Entity, JoinColumn,
+    Entity,
+    JoinColumn,
+    OneToMany,
     OneToOne,
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
-import { Role } from '@shikicinema/types';
 
 import { UploaderEntity } from '~backend/entities';
-import { getIntArrayType } from '~backend/utils/typeorm-helper';
+import { UserRolesEntity } from '~backend/entities/user-roles';
 
 @Entity('users')
 export class UserEntity {
@@ -30,8 +31,8 @@ export class UserEntity {
     @Column()
     email: string;
 
-    @Column({ array: true, type: getIntArrayType() })
-    roles!: Role[];
+    @OneToMany(() => UserRolesEntity, ({ user }) => user)
+    roles: UserRolesEntity[];
 
     @OneToOne(() => UploaderEntity, (uploader) => uploader)
     @JoinColumn({ name: 'uploader_id' })
@@ -52,7 +53,6 @@ export class UserEntity {
         login: string,
         password: string,
         email: string,
-        roles: Role[] = [Role.user],
         uploader: UploaderEntity = null,
         name: string = login,
         createdAt: Date = new Date(),
@@ -61,7 +61,6 @@ export class UserEntity {
         this.login = login;
         this.password = password;
         this.email = email;
-        this.roles = roles;
         this.uploader = uploader;
         this.name = name;
         this.createdAt = createdAt;

--- a/projects/backend/src/guards/no-banned-users-guard.service.ts
+++ b/projects/backend/src/guards/no-banned-users-guard.service.ts
@@ -6,6 +6,7 @@ import {
 import { IRequest } from '~backend/routes/auth/dto';
 import { Role } from '@shikicinema/types';
 import { UserService } from '~backend/services/user/user.service';
+import { userRolesEntityMapToRole } from '~backend/utils/class-transform.utils';
 
 @Injectable()
 export class NoBannedUsersGuard implements CanActivate {
@@ -19,9 +20,9 @@ export class NoBannedUsersGuard implements CanActivate {
             const user = id
                 ? await this.userService.findById(id)
                 : null;
-            // todo replace == with ===
-            // eslint-disable-next-line eqeqeq
-            const hasBannedRole = user.roles.some((role) => role == Role.banned);
+            // TODO: undefined case should be covered!
+            const roles = user?.roles?.map(userRolesEntityMapToRole);
+            const hasBannedRole = roles.some((role) => role === Role.banned);
 
             return !hasBannedRole;
         } catch (e) {

--- a/projects/backend/src/guards/role.guard.ts
+++ b/projects/backend/src/guards/role.guard.ts
@@ -9,6 +9,7 @@ import { Role } from '@shikicinema/types';
 
 import { IRequest } from '~backend/routes/auth/dto';
 import { UserService } from '~backend/services/user/user.service';
+import { userRolesEntityMapToRole } from '~backend/utils/class-transform.utils';
 
 /**
  * List allowed user' roles for a handler or entire controller.
@@ -29,9 +30,7 @@ export class RoleGuard implements CanActivate {
     ) {}
 
     private matchRoles(allowed: Role[], roles: Role[]): boolean {
-        // todo replace == with ===
-        // eslint-disable-next-line eqeqeq
-        return allowed.some((role) => roles.some((r) => r == role));
+        return allowed.some((role) => roles.some((r) => r === role));
     }
 
     private getAllowedRoles(context: ExecutionContext): Role[] {
@@ -51,8 +50,10 @@ export class RoleGuard implements CanActivate {
         try {
             const request = context.switchToHttp().getRequest() as IRequest;
             const user = await this.userService.findById(request.user);
+            // TODO: undefined case should be covered!
+            const userRoles = user?.roles?.map(userRolesEntityMapToRole) || [];
 
-            return this.matchRoles(allowedRoles, user.roles);
+            return this.matchRoles(allowedRoles, userRoles);
         } catch (e) {
             return false;
         }

--- a/projects/backend/src/routes/auth/dto/OwnerUserInfo.dto.ts
+++ b/projects/backend/src/routes/auth/dto/OwnerUserInfo.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose, Type } from 'class-transformer';
 import { Role } from '@shikicinema/types';
-import { TransformRoles } from '~backend/utils/class-transform.utils';
+import { TransformRoles, userRolesEntityMapToRole } from '~backend/utils/class-transform.utils';
 import { UserEntity } from '~backend/entities';
 
 @Exclude()
@@ -52,7 +52,7 @@ export class OwnerUserInfo {
             login,
             name,
             email,
-            roles,
+            roles = [],
             createdAt,
             updatedAt,
             uploader = null,
@@ -62,7 +62,7 @@ export class OwnerUserInfo {
         this.login = login;
         this.name = name;
         this.email = email;
-        this.roles = roles;
+        this.roles = roles ? roles.map(userRolesEntityMapToRole) : [];
         this.shikimoriId = uploader?.shikimoriId;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/projects/backend/src/services/uploader/uploader.shared.module.ts
+++ b/projects/backend/src/services/uploader/uploader.shared.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { UploaderEntity } from '~backend/entities';
@@ -7,7 +7,7 @@ import { UserSharedModule } from '~backend/services/user/user.shared.module';
 
 @Module({
     imports: [
-        UserSharedModule,
+        forwardRef(() => UserSharedModule),
         TypeOrmModule.forFeature([UploaderEntity]),
     ],
     providers: [UploaderService],

--- a/projects/backend/src/services/user/dto/UpdateUser.dto.ts
+++ b/projects/backend/src/services/user/dto/UpdateUser.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsEmail, IsEnum, IsOptional, IsString, Length } from 'class-validator';
 import { Role, UpdateUserRequest } from '@shikicinema/types';
-import { TransformNullableString, TransformRoles } from '~backend/utils/class-transform.utils';
+import { TransformRoles } from '~backend/utils/class-transform.utils';
 
 export class UpdateUser implements UpdateUserRequest {
     @IsOptional()
@@ -26,12 +26,6 @@ export class UpdateUser implements UpdateUserRequest {
     @IsEmail()
     @ApiProperty({ format: 'email' })
     email: string;
-
-    @IsOptional()
-    @IsString()
-    @TransformNullableString()
-    @ApiProperty({ nullable: true })
-    shikimoriId: string | null;
 
     @IsOptional()
     @IsArray()

--- a/projects/backend/src/services/user/user.shared.module.ts
+++ b/projects/backend/src/services/user/user.shared.module.ts
@@ -1,12 +1,16 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { UploaderSharedModule } from '~backend/services/uploader/uploader.shared.module';
 import { UserEntity } from '~backend/entities';
 import { UserService } from '~backend/services/user/user.service';
 
 @Module({
     providers: [UserService],
-    imports: [TypeOrmModule.forFeature([UserEntity])],
+    imports: [
+        forwardRef(() => UploaderSharedModule),
+        TypeOrmModule.forFeature([UserEntity]),
+    ],
     exports: [UserService],
 })
 export class UserSharedModule {}

--- a/projects/backend/src/utils/class-transform.utils.ts
+++ b/projects/backend/src/utils/class-transform.utils.ts
@@ -1,6 +1,9 @@
 import { Role } from '@shikicinema/types';
 import { Transform, TransformOptions } from 'class-transformer';
 
+import { UserEntity } from '~backend/entities/user';
+import { UserRolesEntity } from '~backend/entities/user-roles';
+
 export function TransformNullableString(options?: TransformOptions) {
     return Transform(({ value }) => {
         if (value === undefined) {
@@ -13,10 +16,18 @@ export function TransformNullableString(options?: TransformOptions) {
     }, options);
 }
 
+export const userRolesEntityMapToRole = ({ role }: UserRolesEntity): Role => role;
+
+export const roleMapToString = (role: Role): string => Role[role];
+
+export function plainRoleMapToUserRolesEntity(user: UserEntity, roles: Role[]) {
+    return roles.map((role) => new UserRolesEntity(user, role));
+}
+
 export function TransformRoles() {
     const transform = Transform(
         ({ value }) => value instanceof Array
-            ? value.map((role) => Role[role])
+            ? value.map(roleMapToString)
             : []
     );
 

--- a/projects/backend/src/utils/is-entity.utils.ts
+++ b/projects/backend/src/utils/is-entity.utils.ts
@@ -1,0 +1,3 @@
+export function isEntity<T>(value: any, entityType: new (...args: any[]) => T): value is T {
+    return value === null || value === undefined || value instanceof entityType;
+}

--- a/projects/lib/shikicinema/src/v2/users/UpdateUserRequest.ts
+++ b/projects/lib/shikicinema/src/v2/users/UpdateUserRequest.ts
@@ -6,12 +6,10 @@ import { Role } from './Role';
  *
  * @property {string} [name]        - see {@link User.name}.
  * @property {string} [email]       - see {@link User.email}.
- * @property {number} [shikimoriId] - see {@link User.shikimoriId}.
  * @property {Array<Role>} [roles]  - see {@link User.roles}.
  */
 export interface UpdateUserRequest {
     name?: string;
     email?: string;
-    shikimoriId?: string | null;
     roles?: Role[];
 }


### PR DESCRIPTION
closes #105 

- Вынес роли пользователей в отдельную таблицу (подробнее в #105)
- Исправил скрипт миграции для liquibase для правильной работы из других директорий
- Сиды для тестов зарефакторил
  - Теперь экспортируют только сам класс миграций, без сидов (они всё равно не нужны)
  - Упаковал все сиды в `index.ts`, чтобы их можно было доставать по пути `~backend-root/seeds`
- Наконец-то избавились от костыля с нестрогим равенством `==` в guard'ах
- Добавил ещё несколько утилитарных функций для работы с ролями 